### PR TITLE
Fix duplicate waterlogged property crash with mod subclasses

### DIFF
--- a/Bedrockoid-Fabric/src/main/java/net/sashakyotoz/bedrockoid/mixin/blocks/NotWaterloggableBlockMixin.java
+++ b/Bedrockoid-Fabric/src/main/java/net/sashakyotoz/bedrockoid/mixin/blocks/NotWaterloggableBlockMixin.java
@@ -5,16 +5,41 @@ import net.minecraft.state.StateManager;
 import net.minecraft.state.property.Properties;
 import net.sashakyotoz.bedrockoid.BedrockoidConfig;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import java.util.Set;
+
 @Mixin(value = {LeveledCauldronBlock.class, AnvilBlock.class, BedBlock.class, GrindstoneBlock.class, StonecutterBlock.class,
         LecternBlock.class, HopperBlock.class, BrewingStandBlock.class, BellBlock.class, PressurePlateBlock.class, FenceGateBlock.class})
 public class NotWaterloggableBlockMixin implements Waterloggable {
+
+    @Unique
+    private static final Set<Class<?>> bedrockoid$WATERLOG_TARGETS = Set.of(
+            LeveledCauldronBlock.class, AnvilBlock.class, BedBlock.class, GrindstoneBlock.class, StonecutterBlock.class,
+            LecternBlock.class, HopperBlock.class, BrewingStandBlock.class, BellBlock.class, PressurePlateBlock.class, FenceGateBlock.class
+    );
+
     @Inject(method = "appendProperties", at = @At("HEAD"))
     private void onAppendProperties(StateManager.Builder<Block, BlockState> builder, CallbackInfo ci) {
-        if (BedrockoidConfig.blocksWaterloggability && !((StateDefinitionAccess) builder).getProperties().containsKey(Properties.WATERLOGGED.getName()))
-            builder.add(Properties.WATERLOGGED);
+        if (!BedrockoidConfig.blocksWaterloggability) return;
+        if (((StateDefinitionAccess) builder).getProperties().containsKey(Properties.WATERLOGGED.getName())) return;
+
+        // When a subclass of a targeted block calls super.appendProperties(),
+        // this mixin fires and adds WATERLOGGED. If the subclass also implements
+        // Waterloggable, it will try to add WATERLOGGED again after super returns,
+        // causing a "duplicate property" crash.
+        // Skip for such subclasses and let them handle registration themselves.
+        Block self = (Block) (Object) this;
+        Class<?> cls = self.getClass();
+        if (!bedrockoid$WATERLOG_TARGETS.contains(cls)) {
+            for (Class<?> iface : cls.getInterfaces()) {
+                if (iface == Waterloggable.class) return;
+            }
+        }
+
+        builder.add(Properties.WATERLOGGED);
     }
 }

--- a/Bedrockoid-Neoforge/src/main/java/net/sashakyotoz/bedrockoid/mixin/blocks/waterlog/NotWaterloggableBlockMixin.java
+++ b/Bedrockoid-Neoforge/src/main/java/net/sashakyotoz/bedrockoid/mixin/blocks/waterlog/NotWaterloggableBlockMixin.java
@@ -7,17 +7,41 @@ import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.sashakyotoz.bedrockoid.BedrockoidConfig;
 import net.sashakyotoz.bedrockoid.mixin.blocks.StateDefinitionAccess;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.Set;
 
 @Mixin(value = {LayeredCauldronBlock.class, AnvilBlock.class, GrindstoneBlock.class, StonecutterBlock.class,
         LecternBlock.class, HopperBlock.class, BrewingStandBlock.class, PressurePlateBlock.class, FenceGateBlock.class})
 public class NotWaterloggableBlockMixin implements SimpleWaterloggedBlock {
 
+    @Unique
+    private static final Set<Class<?>> bedrockoid$WATERLOG_TARGETS = Set.of(
+            LayeredCauldronBlock.class, AnvilBlock.class, GrindstoneBlock.class, StonecutterBlock.class,
+            LecternBlock.class, HopperBlock.class, BrewingStandBlock.class, PressurePlateBlock.class, FenceGateBlock.class
+    );
+
     @Inject(method = "createBlockStateDefinition", at = @At("TAIL"))
     private void onAppendProperties(StateDefinition.Builder<Block, BlockState> builder, CallbackInfo ci) {
-        if (BedrockoidConfig.blocksWaterloggability && !((StateDefinitionAccess) builder).getProperties().containsKey(BlockStateProperties.WATERLOGGED.getName()))
-            builder.add(BlockStateProperties.WATERLOGGED);
+        if (!BedrockoidConfig.blocksWaterloggability) return;
+        if (((StateDefinitionAccess) builder).getProperties().containsKey(BlockStateProperties.WATERLOGGED.getName())) return;
+
+        // When a subclass of a targeted block (e.g. Dragon Survival's DragonPressurePlates)
+        // calls super.createBlockStateDefinition(), this mixin fires and adds WATERLOGGED.
+        // If the subclass also implements SimpleWaterloggedBlock, it will try to add
+        // WATERLOGGED again after super returns, causing a "duplicate property" crash.
+        // Skip for such subclasses and let them handle registration themselves.
+        Block self = (Block) (Object) this;
+        Class<?> cls = self.getClass();
+        if (!bedrockoid$WATERLOG_TARGETS.contains(cls)) {
+            for (Class<?> iface : cls.getInterfaces()) {
+                if (iface == SimpleWaterloggedBlock.class) return;
+            }
+        }
+
+        builder.add(BlockStateProperties.WATERLOGGED);
     }
 }


### PR DESCRIPTION
Fixes #14

## Problem

When a mod subclasses one of the mixin targets (e.g. `PressurePlateBlock`) and independently implements `SimpleWaterloggedBlock`, the waterlogging mixin causes a crash:

1. Subclass calls `super.createBlockStateDefinition(builder)`
2. Mixin fires at TAIL of the parent's method and adds `WATERLOGGED` (the `containsKey` guard passes because `WATERLOGGED` isn't in the builder yet)
3. Subclass then adds `WATERLOGGED` itself after super returns
4. Crash: `IllegalArgumentException: Block has duplicate property: waterlogged`

This breaks Dragon Survival's `DragonPressurePlates` (extends `PressurePlateBlock` + implements `SimpleWaterloggedBlock`) and cascades to break Waystones and Create during mod loading.

## Fix

Before adding `WATERLOGGED`, check if the concrete block class is a subclass (not one of the exact mixin targets) that directly implements `SimpleWaterloggedBlock`/`Waterloggable`. If so, skip - the subclass will handle registration itself.

- Vanilla pressure plates and other direct instances of the targeted classes are unaffected
- Vanilla subclasses that don't implement `SimpleWaterloggedBlock` (e.g. `WeightedPressurePlateBlock`) still get waterlogging from Bedrockoid
- Only subclasses that explicitly handle waterlogging themselves are skipped

Both NeoForge and Fabric versions are updated.